### PR TITLE
5 implement api to return the max sale day of a certain time range

### DIFF
--- a/src/main/java/com/wsd/ecommerce_app/controller/SaleController.java
+++ b/src/main/java/com/wsd/ecommerce_app/controller/SaleController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 
 @RestController
@@ -36,10 +35,7 @@ public class SaleController {
             @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
 
-        BigDecimal totalSaleAmount = new BigDecimal("999.99");
-        LocalDate date = LocalDate.of(2024, 7, 5);
-
-        MaxSaleDayDTO maxSaleDayDTO = new MaxSaleDayDTO(date, totalSaleAmount);
+        MaxSaleDayDTO maxSaleDayDTO = saleService.getMaxSaleDay(startDate, endDate);
 
         return ResponseEntity.ok(maxSaleDayDTO);
     }

--- a/src/main/java/com/wsd/ecommerce_app/controller/SaleController.java
+++ b/src/main/java/com/wsd/ecommerce_app/controller/SaleController.java
@@ -1,11 +1,17 @@
 package com.wsd.ecommerce_app.controller;
 
+import com.wsd.ecommerce_app.dto.MaxSaleDayDTO;
 import com.wsd.ecommerce_app.dto.SaleTotalTodayDTO;
 import com.wsd.ecommerce_app.service.SaleService;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/sales")
@@ -23,5 +29,18 @@ public class SaleController {
         SaleTotalTodayDTO dto = saleService.getTodaySaleTotal();
 
         return ResponseEntity.ok(dto);
+    }
+
+    @GetMapping("/max-day")
+    public ResponseEntity<MaxSaleDayDTO> getMaxSaleDay(
+            @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        BigDecimal totalSaleAmount = new BigDecimal("999.99");
+        LocalDate date = LocalDate.of(2024, 7, 5);
+
+        MaxSaleDayDTO maxSaleDayDTO = new MaxSaleDayDTO(date, totalSaleAmount);
+
+        return ResponseEntity.ok(maxSaleDayDTO);
     }
 }

--- a/src/main/java/com/wsd/ecommerce_app/controller/SaleController.java
+++ b/src/main/java/com/wsd/ecommerce_app/controller/SaleController.java
@@ -35,6 +35,10 @@ public class SaleController {
             @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
 
+        if (endDate.isBefore(startDate)) {
+            return ResponseEntity.badRequest().build();
+        }
+
         MaxSaleDayDTO maxSaleDayDTO = saleService.getMaxSaleDay(startDate, endDate);
 
         return ResponseEntity.ok(maxSaleDayDTO);

--- a/src/main/java/com/wsd/ecommerce_app/dto/MaxSaleDayDTO.java
+++ b/src/main/java/com/wsd/ecommerce_app/dto/MaxSaleDayDTO.java
@@ -1,0 +1,33 @@
+package com.wsd.ecommerce_app.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public class MaxSaleDayDTO {
+
+    private LocalDate date;
+    private BigDecimal totalSaleAmount;
+
+    public MaxSaleDayDTO() {}
+
+    public MaxSaleDayDTO(LocalDate date, BigDecimal totalSaleAmount) {
+        this.date = date;
+        this.totalSaleAmount = totalSaleAmount;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public BigDecimal getTotalSaleAmount() {
+        return totalSaleAmount;
+    }
+
+    public void setTotalSaleAmount(BigDecimal totalSaleAmount) {
+        this.totalSaleAmount = totalSaleAmount;
+    }
+}

--- a/src/main/java/com/wsd/ecommerce_app/model/Sale.java
+++ b/src/main/java/com/wsd/ecommerce_app/model/Sale.java
@@ -3,6 +3,7 @@ package com.wsd.ecommerce_app.model;
 import jakarta.persistence.*;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -28,16 +29,20 @@ public class Sale {
     private BigDecimal amount;
 
     @Column(name = "sale_date", nullable = false)
-    private LocalDateTime saleDate;
+    private LocalDate saleDate;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
 
     public Sale() {}
 
-    public Sale(Customer customer, Product product, Integer quantity, BigDecimal amount, LocalDateTime saleDate) {
+    public Sale(Customer customer, Product product, Integer quantity, BigDecimal amount, LocalDate saleDate, LocalDateTime createdAt) {
         this.customer = customer;
         this.product = product;
         this.quantity = quantity;
         this.amount = amount;
         this.saleDate = saleDate;
+        this.createdAt = createdAt;
     }
 
     public Long getId() {
@@ -80,11 +85,19 @@ public class Sale {
         this.amount = amount;
     }
 
-    public LocalDateTime getSaleDate() {
+    public LocalDate getSaleDate() {
         return saleDate;
     }
 
-    public void setSaleDate(LocalDateTime saleDate) {
+    public void setSaleDate(LocalDate saleDate) {
         this.saleDate = saleDate;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/wsd/ecommerce_app/repository/MaxSaleDayProjection.java
+++ b/src/main/java/com/wsd/ecommerce_app/repository/MaxSaleDayProjection.java
@@ -1,0 +1,9 @@
+package com.wsd.ecommerce_app.repository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public interface MaxSaleDayProjection {
+    LocalDate getDate();
+    BigDecimal getTotalSaleAmount();
+}

--- a/src/main/java/com/wsd/ecommerce_app/repository/SaleRepository.java
+++ b/src/main/java/com/wsd/ecommerce_app/repository/SaleRepository.java
@@ -13,4 +13,15 @@ public interface SaleRepository extends JpaRepository<Sale, Long> {
 
     @Query("SELECT COALESCE(SUM(s.amount), 0) FROM Sale s WHERE s.saleDate = :today")
     BigDecimal findTotalSaleAmountForDate(LocalDate today);
+
+    @Query("""
+    SELECT
+      s.saleDate AS date,
+      SUM(s.amount) as totalSaleAmount
+    FROM Sale s
+    WHERE s.saleDate >= :startDate AND s.saleDate <= :endDate
+    GROUP BY s.saleDate
+    ORDER BY SUM(s.amount) DESC, s.saleDate DESC limit 1
+   """)
+    MaxSaleDayProjection findMaxSaleDay(LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/wsd/ecommerce_app/repository/SaleRepository.java
+++ b/src/main/java/com/wsd/ecommerce_app/repository/SaleRepository.java
@@ -6,11 +6,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Repository
 public interface SaleRepository extends JpaRepository<Sale, Long> {
 
-    @Query("SELECT COALESCE(SUM(s.amount), 0) FROM Sale s WHERE s.saleDate >= :startOfDay AND s.saleDate <= :endOfDay")
-    BigDecimal findTotalSaleAmountForDateRange(LocalDateTime startOfDay, LocalDateTime endOfDay);
+    @Query("SELECT COALESCE(SUM(s.amount), 0) FROM Sale s WHERE s.saleDate = :today")
+    BigDecimal findTotalSaleAmountForDate(LocalDate today);
 }

--- a/src/main/java/com/wsd/ecommerce_app/service/SaleService.java
+++ b/src/main/java/com/wsd/ecommerce_app/service/SaleService.java
@@ -1,8 +1,13 @@
 package com.wsd.ecommerce_app.service;
 
+import com.wsd.ecommerce_app.dto.MaxSaleDayDTO;
 import com.wsd.ecommerce_app.dto.SaleTotalTodayDTO;
+
+import java.time.LocalDate;
 
 public interface SaleService {
 
     SaleTotalTodayDTO getTodaySaleTotal();
+
+    MaxSaleDayDTO getMaxSaleDay(LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/wsd/ecommerce_app/service/impl/SaleServiceImpl.java
+++ b/src/main/java/com/wsd/ecommerce_app/service/impl/SaleServiceImpl.java
@@ -2,6 +2,7 @@ package com.wsd.ecommerce_app.service.impl;
 
 import com.wsd.ecommerce_app.dto.MaxSaleDayDTO;
 import com.wsd.ecommerce_app.dto.SaleTotalTodayDTO;
+import com.wsd.ecommerce_app.repository.MaxSaleDayProjection;
 import com.wsd.ecommerce_app.repository.SaleRepository;
 import com.wsd.ecommerce_app.service.SaleService;
 import org.apache.logging.log4j.LogManager;
@@ -10,7 +11,6 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Service
 public class SaleServiceImpl implements SaleService {
@@ -40,17 +40,12 @@ public class SaleServiceImpl implements SaleService {
     @Override
     public MaxSaleDayDTO getMaxSaleDay(LocalDate startDate, LocalDate endDate) {
 
-        BigDecimal totalSaleAmount = new BigDecimal("300.00");
-        LocalDate maxSaleDate = LocalDate.of(2025, 6, 5);
+        MaxSaleDayProjection maxSaleDayProjection = saleRepository.findMaxSaleDay(startDate, endDate);
 
-        LocalDate previousYearDate = LocalDate.of(2024, 12, 31);
-
-        if (endDate.isBefore(previousYearDate)) {
+        if (maxSaleDayProjection == null) {
             return null;
         }
 
-        MaxSaleDayDTO maxSaleDayDTO = new MaxSaleDayDTO(maxSaleDate, totalSaleAmount);
-
-        return maxSaleDayDTO;
+        return new MaxSaleDayDTO(maxSaleDayProjection.getDate(), maxSaleDayProjection.getTotalSaleAmount());
     }
 }

--- a/src/main/java/com/wsd/ecommerce_app/service/impl/SaleServiceImpl.java
+++ b/src/main/java/com/wsd/ecommerce_app/service/impl/SaleServiceImpl.java
@@ -42,10 +42,16 @@ public class SaleServiceImpl implements SaleService {
     @Override
     public MaxSaleDayDTO getMaxSaleDay(LocalDate startDate, LocalDate endDate) {
 
-        BigDecimal totalSaleAmount = new BigDecimal("999.99");
-        LocalDate date = LocalDate.of(2024, 7, 5);
+        BigDecimal totalSaleAmount = new BigDecimal("300.00");
+        LocalDate maxSaleDate = LocalDate.of(2025, 6, 5);
 
-        MaxSaleDayDTO maxSaleDayDTO = new MaxSaleDayDTO(date, totalSaleAmount);
+        LocalDate previousYearDate = LocalDate.of(2024, 12, 31);
+
+        if (endDate.isBefore(previousYearDate)) {
+            return null;
+        }
+
+        MaxSaleDayDTO maxSaleDayDTO = new MaxSaleDayDTO(maxSaleDate, totalSaleAmount);
 
         return maxSaleDayDTO;
     }

--- a/src/main/java/com/wsd/ecommerce_app/service/impl/SaleServiceImpl.java
+++ b/src/main/java/com/wsd/ecommerce_app/service/impl/SaleServiceImpl.java
@@ -27,10 +27,8 @@ public class SaleServiceImpl implements SaleService {
     public SaleTotalTodayDTO getTodaySaleTotal() {
 
         LocalDate today = LocalDate.now();
-        LocalDateTime startOfDay = today.atStartOfDay();
-        LocalDateTime endOfDay = today.plusDays(1).atStartOfDay().minusNanos(1);
 
-        BigDecimal total = saleRepository.findTotalSaleAmountForDateRange(startOfDay, endOfDay);
+        BigDecimal total = saleRepository.findTotalSaleAmountForDate(today);
 
         logger.info("Calculated today's total sales: {}", total);
 

--- a/src/main/java/com/wsd/ecommerce_app/service/impl/SaleServiceImpl.java
+++ b/src/main/java/com/wsd/ecommerce_app/service/impl/SaleServiceImpl.java
@@ -1,5 +1,6 @@
 package com.wsd.ecommerce_app.service.impl;
 
+import com.wsd.ecommerce_app.dto.MaxSaleDayDTO;
 import com.wsd.ecommerce_app.dto.SaleTotalTodayDTO;
 import com.wsd.ecommerce_app.repository.SaleRepository;
 import com.wsd.ecommerce_app.service.SaleService;
@@ -36,5 +37,16 @@ public class SaleServiceImpl implements SaleService {
         total = total != null ? total : BigDecimal.ZERO;
 
         return new SaleTotalTodayDTO(today, total);
+    }
+
+    @Override
+    public MaxSaleDayDTO getMaxSaleDay(LocalDate startDate, LocalDate endDate) {
+
+        BigDecimal totalSaleAmount = new BigDecimal("999.99");
+        LocalDate date = LocalDate.of(2024, 7, 5);
+
+        MaxSaleDayDTO maxSaleDayDTO = new MaxSaleDayDTO(date, totalSaleAmount);
+
+        return maxSaleDayDTO;
     }
 }

--- a/src/test/java/com/wsd/ecommerce_app/controller/SaleControllerTest.java
+++ b/src/test/java/com/wsd/ecommerce_app/controller/SaleControllerTest.java
@@ -1,5 +1,6 @@
 package com.wsd.ecommerce_app.controller;
 
+import com.wsd.ecommerce_app.dto.MaxSaleDayDTO;
 import com.wsd.ecommerce_app.dto.SaleTotalTodayDTO;
 import com.wsd.ecommerce_app.service.SaleService;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -51,12 +53,16 @@ public class SaleControllerTest {
         BigDecimal totalSaleAmount = new BigDecimal("999.99");
         LocalDate date = LocalDate.of(2024, 7, 5);
 
+        MaxSaleDayDTO dto = new MaxSaleDayDTO(date, totalSaleAmount);
+
+        Mockito.when(saleService.getMaxSaleDay(eq(startDate), eq(endDate))).thenReturn(dto);
+
         mockMvc.perform(get("/api/sales/max-day")
                         .param("startDate", startDate.toString())
                         .param("endDate", endDate.toString())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.date").value(date.toString()))
-                .andExpect(jsonPath("$.totalSaleAmount").value(totalSaleAmount));
+                .andExpect(jsonPath("$.date").value(dto.getDate().toString()))
+                .andExpect(jsonPath("$.totalSaleAmount").value(dto.getTotalSaleAmount()));
     }
 }

--- a/src/test/java/com/wsd/ecommerce_app/controller/SaleControllerTest.java
+++ b/src/test/java/com/wsd/ecommerce_app/controller/SaleControllerTest.java
@@ -65,4 +65,36 @@ public class SaleControllerTest {
                 .andExpect(jsonPath("$.date").value(dto.getDate().toString()))
                 .andExpect(jsonPath("$.totalSaleAmount").value(dto.getTotalSaleAmount()));
     }
+
+    @Test
+    void shouldReturnBadRequestWhenEndDateIsBeforeStartDate() throws Exception {
+        mockMvc.perform(get("/api/sales/max-day")
+                        .param("startDate", "2024-07-10")
+                        .param("endDate", "2024-07-01"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturnBadRequestForInvalidDateFormat() throws Exception {
+        mockMvc.perform(get("/api/sales/max-day")
+                        .param("startDate", "07-01-2024")
+                        .param("endDate", "2024-07-10"))
+                .andExpect(status().isBadRequest());
+    }
+
+
+    @Test
+    void shouldReturnBadRequestWhenStartDateIsMissing() throws Exception {
+        mockMvc.perform(get("/api/sales/max-day")
+                        .param("endDate", "2024-07-10"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenEndDateIsMissing() throws Exception {
+        mockMvc.perform(get("/api/sales/max-day")
+                        .param("startDate", "2024-07-01"))
+                .andExpect(status().isBadRequest());
+    }
+
 }

--- a/src/test/java/com/wsd/ecommerce_app/controller/SaleControllerTest.java
+++ b/src/test/java/com/wsd/ecommerce_app/controller/SaleControllerTest.java
@@ -41,4 +41,22 @@ public class SaleControllerTest {
                 .andExpect(jsonPath("$.date").value(today.toString()))
                 .andExpect(jsonPath("$.totalSaleAmount").value(totalSaleAmount));
     }
+
+    @Test
+    void shouldReturnMaxSaleDayForGivenRange() throws Exception {
+
+        LocalDate startDate = LocalDate.of(2024, 7, 1);
+        LocalDate endDate = LocalDate.of(2024, 7, 10);
+
+        BigDecimal totalSaleAmount = new BigDecimal("999.99");
+        LocalDate date = LocalDate.of(2024, 7, 5);
+
+        mockMvc.perform(get("/api/sales/max-day")
+                        .param("startDate", startDate.toString())
+                        .param("endDate", endDate.toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.date").value(date.toString()))
+                .andExpect(jsonPath("$.totalSaleAmount").value(totalSaleAmount));
+    }
 }

--- a/src/test/java/com/wsd/ecommerce_app/repository/SaleRepositoryTest.java
+++ b/src/test/java/com/wsd/ecommerce_app/repository/SaleRepositoryTest.java
@@ -22,10 +22,8 @@ class SaleRepositoryTest {
     void shouldSumAmountBySaleDate() {
 
         LocalDate today = LocalDate.now();
-        LocalDateTime startOfDay = today.atStartOfDay();
-        LocalDateTime endOfDay = today.plusDays(1).atStartOfDay().minusNanos(1);
 
-        BigDecimal totalAmount = saleRepository.findTotalSaleAmountForDateRange(startOfDay, endOfDay);
+        BigDecimal totalAmount = saleRepository.findTotalSaleAmountForDate(today);
 
         assertThat(totalAmount).isNotNull();
         assertThat(totalAmount).isGreaterThanOrEqualTo(BigDecimal.ZERO);

--- a/src/test/java/com/wsd/ecommerce_app/repository/SaleRepositoryTest.java
+++ b/src/test/java/com/wsd/ecommerce_app/repository/SaleRepositoryTest.java
@@ -7,7 +7,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,5 +26,29 @@ class SaleRepositoryTest {
 
         assertThat(totalAmount).isNotNull();
         assertThat(totalAmount).isGreaterThanOrEqualTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    void shouldFindSalesWithinDateRange() {
+
+        LocalDate startDate = LocalDate.of(2025, 6, 2);
+        LocalDate endDate = LocalDate.of(2025, 7, 3);
+
+        MaxSaleDayProjection result = saleRepository.findMaxSaleDay(startDate, endDate);
+
+        assertThat(result.getDate()).isNotNull();
+        assertThat(result.getTotalSaleAmount()).isNotNull();
+        assertThat(result.getTotalSaleAmount()).isGreaterThan(BigDecimal.ZERO);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenNoSales() {
+
+        LocalDate startDate = LocalDate.of(2024, 1, 1);
+        LocalDate endDate = LocalDate.of(2024, 1, 2);
+
+        MaxSaleDayProjection result = saleRepository.findMaxSaleDay(startDate, endDate);
+
+        assertThat(result).isNull();
     }
 }

--- a/src/test/java/com/wsd/ecommerce_app/service/SaleServiceTest.java
+++ b/src/test/java/com/wsd/ecommerce_app/service/SaleServiceTest.java
@@ -1,5 +1,6 @@
 package com.wsd.ecommerce_app.service;
 
+import com.wsd.ecommerce_app.dto.MaxSaleDayDTO;
 import com.wsd.ecommerce_app.dto.SaleTotalTodayDTO;
 import com.wsd.ecommerce_app.repository.SaleRepository;
 import com.wsd.ecommerce_app.service.impl.SaleServiceImpl;
@@ -42,5 +43,31 @@ class SaleServiceTest {
 
         assertThat(dto.getDate()).isEqualTo(today);
         assertThat(dto.getTotalSaleAmount()).isEqualTo(totalAmount);
+    }
+
+    @Test
+    void shouldReturnMaxSaleDayWithinRange() {
+
+        LocalDate startDate = LocalDate.of(2025, 6, 1);
+        LocalDate endDate = LocalDate.of(2025, 7, 3);
+
+        BigDecimal totalSaleAmount = new BigDecimal("300.00");
+        LocalDate maxSaleDate = LocalDate.of(2025, 6, 5);
+
+        MaxSaleDayDTO result = saleService.getMaxSaleDay(startDate, endDate);
+
+        assertThat(result.getDate()).isEqualTo(maxSaleDate);
+        assertThat(result.getTotalSaleAmount()).isEqualByComparingTo(totalSaleAmount);
+    }
+
+    @Test
+    void shouldReturnNullIfNoSalesInRange() {
+
+        LocalDate startDate = LocalDate.of(2024, 8, 1);
+        LocalDate endDate = LocalDate.of(2024, 8, 2);
+
+        MaxSaleDayDTO result = saleService.getMaxSaleDay(startDate, endDate);
+
+        assertThat(result).isNull();
     }
 }

--- a/src/test/java/com/wsd/ecommerce_app/service/SaleServiceTest.java
+++ b/src/test/java/com/wsd/ecommerce_app/service/SaleServiceTest.java
@@ -2,6 +2,7 @@ package com.wsd.ecommerce_app.service;
 
 import com.wsd.ecommerce_app.dto.MaxSaleDayDTO;
 import com.wsd.ecommerce_app.dto.SaleTotalTodayDTO;
+import com.wsd.ecommerce_app.repository.MaxSaleDayProjection;
 import com.wsd.ecommerce_app.repository.SaleRepository;
 import com.wsd.ecommerce_app.service.impl.SaleServiceImpl;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -52,6 +52,20 @@ class SaleServiceTest {
         BigDecimal totalSaleAmount = new BigDecimal("300.00");
         LocalDate maxSaleDate = LocalDate.of(2025, 6, 5);
 
+        when(saleRepository.findMaxSaleDay(startDate, endDate)).thenReturn(
+                new MaxSaleDayProjection() {
+                    @Override
+                    public LocalDate getDate() {
+                        return maxSaleDate;
+                    }
+
+                    @Override
+                    public BigDecimal getTotalSaleAmount() {
+                        return totalSaleAmount;
+                    }
+                }
+        );
+
         MaxSaleDayDTO result = saleService.getMaxSaleDay(startDate, endDate);
 
         assertThat(result.getDate()).isEqualTo(maxSaleDate);
@@ -63,6 +77,9 @@ class SaleServiceTest {
 
         LocalDate startDate = LocalDate.of(2024, 8, 1);
         LocalDate endDate = LocalDate.of(2024, 8, 2);
+
+        when(saleRepository.findMaxSaleDay(startDate, endDate))
+                .thenReturn(null);
 
         MaxSaleDayDTO result = saleService.getMaxSaleDay(startDate, endDate);
 

--- a/src/test/java/com/wsd/ecommerce_app/service/SaleServiceTest.java
+++ b/src/test/java/com/wsd/ecommerce_app/service/SaleServiceTest.java
@@ -31,12 +31,10 @@ class SaleServiceTest {
     void shouldReturnTodayTotalSales() {
 
         LocalDate today = LocalDate.now();
-        LocalDateTime startOfDay = today.atStartOfDay();
-        LocalDateTime endOfDay = today.plusDays(1).atStartOfDay().minusNanos(1);
 
         BigDecimal totalAmount = new BigDecimal("999.99");
 
-        when(saleRepository.findTotalSaleAmountForDateRange(startOfDay, endOfDay))
+        when(saleRepository.findTotalSaleAmountForDate(today))
                 .thenReturn(totalAmount);
 
         SaleTotalTodayDTO dto = saleService.getTodaySaleTotal();


### PR DESCRIPTION
### Overview
Implements the Max Sale Day API following TDD principles. The API returns the day with the highest sales within a given date range, including the total amount.

### Features
✅ GET /api/sales/max-day - Retrieve day with highest sales in date range
✅ Date Range Filtering - Query sales between start and end dates
✅ Aggregation Logic - Find maximum sales day with ranking
✅ Comprehensive Testing - Repository, Service, Controller tests

### API Specification
**Endpoint**: GET /api/sales/max-day

### Response
{
  "date": "2025-01-15",
  "totalAmount": "599.97"
}